### PR TITLE
Fix nil itemName

### DIFF
--- a/ItemTooltipProfessionIcons.lua
+++ b/ItemTooltipProfessionIcons.lua
@@ -89,6 +89,7 @@ end
 local function ModifyItemTooltip( tt ) 
 		
 	local itemName, itemLink = tt:GetItem() 
+	if not itemName then return end
 	local itemID = select( 1, GetItemInfoInstant( itemName ) )
 	
 	if itemID == nil then


### PR DESCRIPTION
Some addon, like ATT, creates tooltip without setting itemName, check nil before calling GetItemInfoInstant

fixes #1, fixes #2